### PR TITLE
Improves project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # carna-ng
-New Implementation of www.carna.io with proper small screen support using:
+New implementation of <u>[www.carna.io](https://www.carna.io)</u>.
+A body index and body fat percentage calculator with proper small screen and offline support.
+This project also serves as a learning project and guide for learning Elm and setting up [Elm](http://elm-lang.org/), [webpack](https://webpack.github.io/) and optionally [Haskell](https://www.haskell.org/) for the backend.
+
+If you are interested in the Elm frontend just skip directly to the
+[**Elm-Frontend Readme**](carna-ui/README.md) or browse the code under [carna-ui](carna-ui/).
+
+## Technologies used
+### Frontend
 * Elm
-* Material design lite
-* Haskell
-* Spock
+* Material design lite [Elm mdl](https://debois.github.io/elm-mdl/)
 * Webpack
+
+### Backend
+* [Haskell](https://www.haskell.org/)
+* [Spock](https://www.spock.li/)

--- a/carna-ui/README.md
+++ b/carna-ui/README.md
@@ -1,13 +1,22 @@
-# Elm project
+# Carna frontend application
 [![Build Status](https://travis-ci.org/scepticulous/carna-ng.svg?branch=master)](https://travis-ci.org/scepticulous/carna-ng)
-## Getting started
 
-You need to have [Elm](http://elm-lang.org/) 0.18 installed on your machine.
+This is the actual implementation of [www.carna.io](https://www.carna.io), since it is now
+a single page application and the entire logic is implemented in the frontend.
 
-Compile this project with:
+# About
+This project is mostly a learning project that can also be used as a reference because it covers most of the topics that an Elm programmer might need to touch when implementing a real world web application.
+These concerns are:
 
-    elm make src/Main.elm
-
-Then view it:
-
-    elm reactor
+* HTTP requests
+* Tasks
+* Encoding / Decoding JSON
+* javascript startup input via `flags`
+* Using JS libraries via `ports`
+* Reading and writing local store
+* Navigation / setting URLs
+* Url parsing for navigation
+* webpack configuration
+* Unit tests
+* Fuzz testing
+* User interface with material UI (elm-mdl)


### PR DESCRIPTION
In order to let people find the actual frontend app when visiting
the repository the project README and the frontend app README have
been improved. Now it should be able for people to have an initial
understanding and some orientation when looking at the READMEs.